### PR TITLE
NullPointerException is fixed

### DIFF
--- a/android/src/main/java/io/github/mr03web/softinputmodemodule/SoftInputModeModule.java
+++ b/android/src/main/java/io/github/mr03web/softinputmodemodule/SoftInputModeModule.java
@@ -38,7 +38,12 @@ public class SoftInputModeModule extends ReactContextBaseJavaModule {
         @Override
         public void handleMessage(Message msg) {
             super.handleMessage(msg);
-            getCurrentActivity().getWindow().setSoftInputMode(msg.what);
+            try {
+                getCurrentActivity().getWindow().setSoftInputMode(msg.what);
+            }
+            catch(Exception e) {
+
+            }
         }
     };
 


### PR DESCRIPTION
Sometimes crashlytics reports that `NullPointerException` occurred on line 41. Seems like `getCurrentActivity()` or `getWindow()` returns null in such cases.